### PR TITLE
Potential fix for code scanning alert no. 15: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -8982,7 +8982,16 @@ def save_cropped_image():
         db.update_user_profile_image(current_user['id'], filename)
 
         # Delete the temporary file
-        temp_path = os.path.join(current_dir, 'static', 'temp', temp_filename)
+        # Sanitize and validate the temp_filename
+        from werkzeug.utils import secure_filename
+        safe_filename = secure_filename(temp_filename)
+        temp_path = os.path.normpath(os.path.join(current_dir, 'static', 'temp', safe_filename))
+
+        # Ensure the temp_path is within the intended directory
+        temp_dir = os.path.normpath(os.path.join(current_dir, 'static', 'temp'))
+        if not temp_path.startswith(temp_dir):
+            raise ValueError("Invalid file path")
+
         if os.path.exists(temp_path):
             os.remove(temp_path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/totovskimartin/certifly/security/code-scanning/15](https://github.com/totovskimartin/certifly/security/code-scanning/15)

To fix the issue, we need to validate and sanitize the `temp_filename` to ensure it does not contain malicious input. The best approach is to:
1. Use `os.path.normpath` to normalize the path and remove any `..` segments.
2. Ensure that the resulting path is contained within the intended directory (`static/temp`).
3. Optionally, use a library like `werkzeug.utils.secure_filename` to sanitize the filename and remove any special characters.

The changes will be made in the `save_cropped_image` function, specifically around the construction and validation of `temp_path`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
