### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -8982,7 +8982,19 @@ def save_cropped_image():
         db.update_user_profile_image(current_user['id'], filename)
 
         # Delete the temporary file
-        temp_path = os.path.join(current_dir, 'static', 'temp', temp_filename)
+        # Define the base directory for temporary files
+        temp_base_dir = os.path.join(current_dir, 'static', 'temp')
+
+        # Normalize and validate the temp_filename
+        temp_filename = os.path.normpath(temp_filename)
+        if not temp_filename or temp_filename.startswith("..") or os.path.isabs(temp_filename):
+            raise ValueError("Invalid filename")
+
+        # Construct the full path and ensure it is within the base directory
+        temp_path = os.path.join(temp_base_dir, temp_filename)
+        if not temp_path.startswith(temp_base_dir):
+            raise ValueError("Invalid file path")
+
         if os.path.exists(temp_path):
             os.remove(temp_path)
 


### PR DESCRIPTION
Potential fix for [https://github.com/totovskimartin/certifly/security/code-scanning/14](https://github.com/totovskimartin/certifly/security/code-scanning/14)

To fix the issue, we need to validate and sanitize the `temp_filename` before using it to construct the `temp_path`. A good approach is to:
1. Use `os.path.normpath` to normalize the path and remove any `..` segments.
2. Ensure that the resulting path is within the intended directory (`static/temp`) by checking that it starts with the base directory.
3. Optionally, use a library like `werkzeug.utils.secure_filename` to sanitize the filename and remove any special characters.

The changes will be made in the `save_cropped_image` function, specifically around the construction and validation of `temp_path`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
