### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -8920,7 +8920,12 @@ def crop_profile_image(filename):
 
     # Check if the temporary file exists
     import os
-    temp_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'temp', filename)
+    base_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'static', 'temp')
+    temp_path = os.path.normpath(os.path.join(base_path, filename))
+    if not temp_path.startswith(base_path):
+        logger.error(f"Invalid file path: {temp_path}")
+        flash("Error: Invalid file path.", "error")
+        return redirect(url_for('profile'))
     if os.path.exists(temp_path):
         logger.info(f"Temporary file exists at: {temp_path}")
     else:


### PR DESCRIPTION
Potential fix for [https://github.com/totovskimartin/certifly/security/code-scanning/13](https://github.com/totovskimartin/certifly/security/code-scanning/13)

To fix the issue, we need to validate the `filename` parameter to ensure it does not contain malicious input. The best approach is to:
1. Normalize the constructed path using `os.path.normpath` to remove any `..` segments or redundant separators.
2. Verify that the normalized path starts with the intended base directory (`static/temp`) to ensure the file is within the allowed directory.
3. Optionally, use a stricter validation mechanism, such as `werkzeug.utils.secure_filename`, to sanitize the `filename` and prevent special characters.

The changes will be made in the `crop_profile_image` function, specifically where the `temp_path` is constructed and validated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
