### PR TITLE
Potential fix for code scanning alert no. 22: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -5520,9 +5520,12 @@ def clear_ssl_cache(domain):
     # Redirect back to the referring page or to the SSL certificates page
     referrer = request.referrer
     if referrer:
-        return redirect(referrer)
-    else:
-        return redirect(url_for('ssl_certificates'))
+        from urllib.parse import urlparse
+        parsed_url = urlparse(referrer)
+        # Allow only relative URLs or URLs from trusted domains
+        if not parsed_url.netloc or parsed_url.netloc.endswith('yourtrustedomain.com'):
+            return redirect(referrer)
+    return redirect(url_for('ssl_certificates'))
 
 @app.route('/clear_all_ssl_cache')
 @auth.login_required


### PR DESCRIPTION
Potential fix for [https://github.com/totovskimartin/certifly/security/code-scanning/22](https://github.com/totovskimartin/certifly/security/code-scanning/22)

To fix the issue, we need to validate the `referrer` value before using it in the `redirect()` function. A common approach is to ensure that the `referrer` URL belongs to a trusted domain or is a relative URL. This can be achieved using the `urlparse` function from Python's standard library to parse the URL and check its `netloc` attribute. If the `referrer` is not valid, we should fall back to a safe, predefined URL.

The fix involves:
1. Parsing the `referrer` URL using `urlparse`.
2. Checking that the `referrer` is either a relative URL (empty `netloc`) or belongs to a trusted domain.
3. Redirecting to the `referrer` only if it passes validation; otherwise, redirecting to a safe fallback URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
