### PR TITLE
Potential fix for code scanning alert no. 23: URL redirection from remote source

### DIFF
--- a/app.py
+++ b/app.py
@@ -8034,7 +8034,13 @@ def switch_organization(org_id):
     else:
         flash("You don't have access to this organization", 'error')
 
-    return redirect(request.referrer or url_for('index'))
+    from urllib.parse import urlparse
+    referrer = request.referrer
+    if referrer:
+        parsed_url = urlparse(referrer)
+        if parsed_url.netloc != request.host:
+            referrer = None
+    return redirect(referrer or url_for('index'))
 
 @app.route('/organizations/create', methods=['GET', 'POST'])
 @auth.admin_required


### PR DESCRIPTION
Potential fix for [https://github.com/totovskimartin/certifly/security/code-scanning/23](https://github.com/totovskimartin/certifly/security/code-scanning/23)

To fix the issue, we need to validate the `request.referrer` value before using it in the redirect. A safe approach is to check that the `request.referrer` URL belongs to the same host as the application. This can be achieved using the `urlparse` function from Python's standard library to parse the URL and compare its `netloc` with the application's host.

If the `request.referrer` is invalid or does not match the application's host, we should redirect the user to a safe default location, such as the home page (`url_for('index')`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
